### PR TITLE
maintain compatibility with qrencode pre-v3.4.0

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -10,8 +10,8 @@ var Encoder = exports.Encoder = function(){
 util.inherits(Encoder, events.EventEmitter);
 
 Encoder.prototype.default_options = {
-    foreground_color: '#000000',
-    background_color: '#FFFFFF',
+    foreground_color: '#000000', // change foreground color in qrencode v3.4.0+
+    background_color: '#FFFFFF', // change background color in qrencode v3.4.0+
     dot_size: 3, // default 3x3px per dot
     margin: 4, // default 4 dots for the margin
     level: 'L', // valid args (lowest to highest): L, M, Q, H
@@ -51,19 +51,28 @@ Encoder.prototype.encode = function(value, path, options)
                 : options[key];
         }
         
-        // remove # symbol from color codes because qrencoder does not like it
-        cmd_options.foreground_color = cmd_options.foreground_color.replace('#', '');
-        cmd_options.background_color = cmd_options.background_color.replace('#', '');
-        
         // start with base set of args that we'll always pass
         qrencode_args = [
             '-s', cmd_options.dot_size, 
             '-m', cmd_options.margin,
             '-l', cmd_options.level,
-            '-v', cmd_options.version,
+            '-v', cmd_options.version
+        ];
+        
+        // only set foreground and background colors if they differ from
+        // defaults to maintain compatibility with qrencode pre-v3.4.0
+        if(cmd_options.foreground_color !== self.default_options.foreground_color
+          || cmd_options.background_color !== self.default_options.background_color) {
+          
+          // remove # symbol from color codes because qrencoder does not like it
+          cmd_options.foreground_color = cmd_options.foreground_color.replace('#', '');
+          cmd_options.background_color = cmd_options.background_color.replace('#', '');
+          
+          qrencode_args.push(
             '--foreground=' + cmd_options.foreground_color,
             '--background=' + cmd_options.background_color
-        ];
+          );
+        }
         
         // if case-sensitivity is disabled, add flag
         if(!cmd_options.case_sensitive) qrencode_args.push('-i');


### PR DESCRIPTION
By only setting foreground and background flags when they differ
from the defaults, we can maintain compatibility pre-v3.4.0 before
support for colored QR codes was added.
