### PR TITLE
Move testing packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "homepage": "https://github.com/heavyco/node-qr",
     "keywords": ["qr", "qrcode", "qrencode", "qrencoder"],
     "main": "./qr.js",
-    "dependencies": {
+    "dependencies": {},
+    "devDependencies": {
         "vows": ">= 0.5.8",
         "benchmark": ""
     },


### PR DESCRIPTION
As the listed dependencies aren't needed for the library to run, but only for testing, I propose them to be moved to `devDependencies`, thus decrease bundle size and get rid of packages which wouldn't be ever used by dependents.